### PR TITLE
WIP: Make it compile with current llvm-hs and add some operations

### DIFF
--- a/llvm-hs-pretty.cabal
+++ b/llvm-hs-pretty.cabal
@@ -19,6 +19,7 @@ Source-Repository head
     Location: git@github.com:llvm-hs/llvm-hs-pretty.git
 
 library
+  ghc-options:         -Wall
   hs-source-dirs:      src
   exposed-modules:     
     LLVM.Pretty
@@ -28,9 +29,11 @@ library
     base                 >= 4.6   && < 5.0,
     llvm-hs-pure         >= 4.0,
     text                 >= 0.1,
-    wl-pprint-text       >= 1.1
+    wl-pprint-text       >= 1.1,
+    bytestring
 
 executable llp
+  ghc-options:         -Wall
   hs-source-dirs:      tests
   main-is:             Main.hs
   default-language:    Haskell2010
@@ -48,6 +51,7 @@ executable llp
     llvm-hs-pure         >= 4.0
 
 Test-suite test
+  ghc-options:         -Wall
   type:                exitcode-stdio-1.0
   hs-source-dirs:      tests
   main-is:             Main.hs

--- a/src/LLVM/Pretty.hs
+++ b/src/LLVM/Pretty.hs
@@ -278,6 +278,7 @@ instance PP Instruction where
 
     BitCast {..} -> "bitcast" <+> ppTyped operand0 <+> "to" <+> pp type'
     PtrToInt {..} -> "ptrtoint" <+> ppTyped operand0 <+> "to" <+> pp type'
+    IntToPtr {..} -> "inttoptr" <+> ppTyped operand0 <+> "to" <+> pp type'
 
     x -> error (show x)
 
@@ -314,6 +315,10 @@ instance PP C.Constant where
       PointerType argTy _ = typeOf address
       bounds True = "inbounds"
       bounds False = empty
+
+  pp C.BitCast {..} = "bitcast" <+> parens (ppTyped operand0 <+> "to" <+> pp type')
+  pp C.PtrToInt {..} = "ptrtoint" <+> parens (ppTyped operand0 <+> "to" <+> pp type')
+  pp C.IntToPtr {..} = "inttoptr" <+> parens (ppTyped operand0 <+> "to" <+> pp type')
 
   pp x = error (show x)
 

--- a/src/LLVM/Pretty.hs
+++ b/src/LLVM/Pretty.hs
@@ -407,7 +407,6 @@ ppCall :: Instruction -> Doc
 ppCall Call { function = Right f,..}
   = tail <+> "call" <+> pp resultType <+> ftype <+> pp f <> parens (commas $ fmap pp arguments)
     where
-      tail = if isTailCall tailCallKind then "tail" else empty
       (functionType@FunctionType {..}) = referencedType (typeOf f)
       ftype = if isVarArg || isFunctionPtr resultType
               then ppFunctionArgumentTypes functionType <> "*"
@@ -415,9 +414,10 @@ ppCall Call { function = Right f,..}
       referencedType (PointerType t _) = referencedType t
       referencedType t                 = t
 
-      -- xxx: tail call kind hack
-      isTailCall Nothing = False
-      isTailCall (Just a) = True
+      tail = case tailCallKind of
+        Just Tail -> "tail"
+        Just MustTail -> "musttail"
+        Nothing -> empty
 
 ppCall x = error (show x)
 

--- a/src/LLVM/Pretty.hs
+++ b/src/LLVM/Pretty.hs
@@ -30,6 +30,7 @@ import qualified LLVM.AST.Float as F
 import LLVM.AST.FunctionAttribute
 
 import Data.String
+import qualified Data.ByteString.Short as SB
 
 import Text.Printf
 import Data.Text.Lazy (Text, pack, unpack)
@@ -78,6 +79,9 @@ isFunctionPtr _ = False
 cma :: Doc -> Doc -> Doc -- <,> does not work :(
 a `cma` b = a <> "," <+> b
 
+sb2text :: SB.ShortByteString -> Text
+sb2text = pack . map (chr . fromIntegral) . SB.unpack
+
 -------------------------------------------------------------------------------
 -- Classes
 -------------------------------------------------------------------------------
@@ -98,13 +102,13 @@ instance PP Integer where
   pp = integer
 
 instance PP Name where
-  pp (Name []) = dquotes empty
-  pp (Name name@(first:_))
-    | isFirst first && all isRest name = text (pack name)
-    | otherwise = dquotes . hcat . map escape $ name
-    where
-        isFirst c = isLetter c || c == '-' || c == '_'
-        isRest c = isDigit c || isFirst c
+  pp (Name n) = go $ unpack $ sb2text n
+    where go [] = dquotes empty
+          go name@(first:_)
+            | isFirst first && all isRest name = text (pack name)
+            | otherwise = dquotes . hcat . map escape $ name
+          isFirst c = isLetter c || c == '-' || c == '_'
+          isRest c = isDigit c || isFirst c
   pp (UnName x) = int (fromIntegral x)
 
 instance PP Parameter where
@@ -164,7 +168,7 @@ instance PP Definition where
   pp (GlobalDefinition x) = pp x
   pp (TypeDefinition nm ty) = local (pp nm) <+> "=" <+> "type" <+> maybe "opaque" pp ty
   pp (FunctionAttributes gid attrs) = "attributes" <+> pp gid <+> "=" <+> braces (hsep (fmap pp attrs))
-  pp (NamedMetadataDefinition nm meta) = text (pack nm)
+  pp (NamedMetadataDefinition nm meta) = text (sb2text nm)
   pp (MetadataNodeDefinition node meta) = pp node
 
 instance PP FunctionAttribute where
@@ -197,7 +201,7 @@ instance PP FunctionAttribute where
    SanitizeAddress     -> "TODO"
    SanitizeThread      -> "TODO"
    SanitizeMemory      -> "TODO"
-   StringAttribute k v -> dquotes (text (pack k)) <> "=" <> dquotes (text (pack v))
+   StringAttribute k v -> dquotes (text (sb2text k)) <> "=" <> dquotes (text (sb2text v))
 
 instance PP L.Linkage where
     pp = ppLinkage False
@@ -319,8 +323,8 @@ instance PP a => PP (Named a) where
 
 instance PP Module where
   pp Module {..} =
-    let header = printf "; ModuleID = '%s'" moduleName in
-    hlinecat (fromString header : (fmap pp moduleDefinitions))
+    let header = "; ModuleID = '" <> sb2text moduleName <> "'"
+    in hlinecat (pretty header : (fmap pp moduleDefinitions))
 
 instance PP FP.FloatingPointPredicate where
   pp op = case op of

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,7 @@
-resolver: lts-7.8
+resolver: nightly-2017-04-09
 packages:
 - '.'
-extra-deps:
-- llvm-hs-pure-4.0.0.0
-- llvm-hs-4.0.0.0
-
-flags:
-  llvm-hs:
-    shared-llvm: true
+- location: ../llvm/llvm-hs-pure
+  extra-dep: True
+- location: ../llvm/llvm-hs
+  extra-dep: True


### PR DESCRIPTION
Maybe we should also switch the whole thing to bytestring to stay compatible with llvm-hs. But then it wouldn't make sense to use wl-pprint-text. Shall we switch to wl-pprint then?