### PR TITLE
Fixes and additions

### DIFF
--- a/llvm-hs-pretty.cabal
+++ b/llvm-hs-pretty.cabal
@@ -30,23 +30,6 @@ library
     text                 >= 0.1,
     wl-pprint-text       >= 1.1
 
-executable llp
-  hs-source-dirs:      tests
-  main-is:             Main.hs
-  default-language:    Haskell2010
-  build-depends: 
-    base                 >= 4.6 && < 5.0,
-    text                 >= 0.1,
-    mtl                  >= 2.2,
-    transformers         >= 0.3 && < 0.6,
-    directory            >= 1.2,
-    filepath             >= 1.3,
-    pretty-show          >= 1.6 && < 1.7,
-    wl-pprint-text       >= 1.1,
-    llvm-hs-pretty       >= 0.1,
-    llvm-hs              >= 4.0,
-    llvm-hs-pure         >= 4.0
-
 Test-suite test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      tests

--- a/src/LLVM/Pretty.hs
+++ b/src/LLVM/Pretty.hs
@@ -72,9 +72,6 @@ global a = "@" <> a
 label :: Doc -> Doc
 label a = "label" <+> "%" <> a
 
-isFunctionPtr (PointerType FunctionType {..} _) = True
-isFunctionPtr _ = False
-
 cma :: Doc -> Doc -> Doc -- <,> does not work :(
 a `cma` b = a <> "," <+> b
 
@@ -448,8 +445,8 @@ ppCall Call { function = Right f,..}
   = tail <+> "call" <+> pp callingConvention <+> pp resultType <+> ftype <+> pp f <> parens (commas $ fmap pp arguments)
     where
       (functionType@FunctionType {..}) = referencedType (typeOf f)
-      ftype = if isVarArg || isFunctionPtr resultType
-              then ppFunctionArgumentTypes functionType <> "*"
+      ftype = if isVarArg
+              then ppFunctionArgumentTypes functionType
               else empty
       referencedType (PointerType t _) = referencedType t
       referencedType t                 = t

--- a/src/LLVM/Pretty.hs
+++ b/src/LLVM/Pretty.hs
@@ -108,6 +108,7 @@ instance PP Name where
   pp (UnName x) = int (fromIntegral x)
 
 instance PP Parameter where
+  pp (Parameter ty (UnName _) attrs) = pp ty
   pp (Parameter ty name attrs) = pp ty <+> local (pp name)
 
 instance PP ([Parameter], Bool) where

--- a/src/LLVM/Pretty.hs
+++ b/src/LLVM/Pretty.hs
@@ -343,6 +343,7 @@ instance PP C.Constant where
 
   pp (C.Struct _ _ elems) = spacedbraces $ commas $ fmap ppTyped elems
   pp (C.Null {}) = "null"
+  pp (C.Undef {}) = "undef"
 
   pp C.Array {..}
     | memberType == (IntegerType 8) = "c" <> (dquotes $ hcat [ppIntAsChar val | C.Int _ val <- memberValues])

--- a/src/LLVM/Pretty.hs
+++ b/src/LLVM/Pretty.hs
@@ -114,6 +114,10 @@ instance PP ([Parameter], Bool) where
 instance PP (Operand, [ParameterAttribute]) where
   pp (op, attrs) = ppTyped op
 
+instance PP UnnamedAddr where
+  pp LocalAddr = "local_unnamed_addr"
+  pp GlobalAddr = "unnamed_addr"
+
 instance PP Type where
   pp (IntegerType width) = "i" <> pp width
   pp (FloatingPointType 16    IEEE) = "half"
@@ -156,14 +160,14 @@ instance PP Global where
       fnAttrs = hsep $ fmap pp functionAttributes
       gcName = maybe empty (\n -> "gc" <+> dquotes (text $ pack n)) garbageCollectorName
 
-  pp (GlobalVariable {..}) = global (pp name) <+> "=" <+> ppLinkage hasInitializer linkage <+> kind <+> pp type'
-                             <+> ppMaybe initializer <> ppAlign alignment
+  pp (GlobalVariable {..}) = global (pp name) <+> "=" <+> ppLinkage hasInitializer linkage <+> ppMaybe unnamedAddr
+                             <+> kind <+> pp type' <+> ppMaybe initializer <> ppAlign alignment
     where
       hasInitializer = isJust initializer
       kind | isConstant = "constant"
            | otherwise  = "global"
 
-  pp (GlobalAlias {..}) = global (pp name) <+> "=" <+> pp linkage <+> "alias" <+> pp typ `cma` ppTyped aliasee
+  pp (GlobalAlias {..}) = global (pp name) <+> "=" <+> pp linkage <+> ppMaybe unnamedAddr <+> "alias" <+> pp typ `cma` ppTyped aliasee
     where
       PointerType typ _ = type'
 

--- a/tests/input/comparison.ll
+++ b/tests/input/comparison.ll
@@ -4,7 +4,7 @@ define i1 @main(i32 %x) {
 entry:
   %x.addr = alloca i32
   store i32 %x, i32* %x.addr
-  %0 = load i32* %x.addr
+  %0 = load i32, i32* %x.addr
   %1 = icmp ult i32 %0, 1
   ret i1 %1
 }

--- a/tests/input/debug.ll
+++ b/tests/input/debug.ll
@@ -6,6 +6,6 @@ declare i32 @printf(i8*, ...)
 
 define i32 @main() {
 entry:
-  %0 = call i32 (i8*, ...)* @printf(i8* getelementptr inbounds ([3 x i8]* @"%i", i32 0, i32 0), i32 42)
+  %0 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @"%i", i32 0, i32 0), i32 42)
   ret i32 %0
 }

--- a/tests/input/float.ll
+++ b/tests/input/float.ll
@@ -13,7 +13,7 @@ define double @bar(double %a) {
 entry:
   %0 = alloca double
   store double %a, double* %0
-  %1 = load double* %0
+  %1 = load double, double* %0
   %2 = call double @foo(double %1, double 4.000000e+00)
   %3 = call double @bar(double 3.133700e+04)
   %4 = fadd double %2, %3

--- a/tests/input/for.ll
+++ b/tests/input/for.ll
@@ -9,11 +9,11 @@ entry:
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
-  %1 = load i32* %0
+  %1 = load i32, i32* %0
   br i1 true, label %for.loop, label %for.exit
 
 for.loop:                                         ; preds = %for.cond
-  %2 = load i32* %0
+  %2 = load i32, i32* %0
   %3 = alloca i32
   store i32 0, i32* %3
   br label %for.cond1
@@ -27,11 +27,11 @@ for.exit:                                         ; preds = %for.cond
   ret i32 0
 
 for.cond1:                                        ; preds = %for.inc1, %for.loop
-  %5 = load i32* %3
+  %5 = load i32, i32* %3
   br i1 true, label %for.loop1, label %for.exit1
 
 for.loop1:                                        ; preds = %for.cond1
-  %6 = load i32* %3
+  %6 = load i32, i32* %3
   %7 = call i32 @foo()
   br label %for.inc1
 

--- a/tests/input/full.ll
+++ b/tests/input/full.ll
@@ -11,12 +11,12 @@ entry:
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
-  %1 = load i32* %0
+  %1 = load i32, i32* %0
   %2 = icmp ult i32 %1, 15
   br i1 %2, label %for.loop, label %for.exit
 
 for.loop:                                         ; preds = %for.cond
-  %3 = load i32* %0
+  %3 = load i32, i32* %0
   %4 = alloca i32
   store i32 0, i32* %4
   br label %for.cond1
@@ -30,12 +30,12 @@ for.exit:                                         ; preds = %for.cond
   ret i32 0
 
 for.cond1:                                        ; preds = %for.inc1, %for.loop
-  %6 = load i32* %4
+  %6 = load i32, i32* %4
   %7 = icmp ult i32 %6, 15
   br i1 %7, label %for.loop1, label %for.exit1
 
 for.loop1:                                        ; preds = %for.cond1
-  %8 = load i32* %4
+  %8 = load i32, i32* %4
   %9 = add i32 %3, %8
   %10 = call i32 (i8*, ...)* @printf(i8* getelementptr inbounds ([3 x i8]* @"%i", i32 0, i32 0), i32 %9)
   br label %for.inc1

--- a/tests/input/full.ll
+++ b/tests/input/full.ll
@@ -37,7 +37,7 @@ for.cond1:                                        ; preds = %for.inc1, %for.loop
 for.loop1:                                        ; preds = %for.cond1
   %8 = load i32, i32* %4
   %9 = add i32 %3, %8
-  %10 = call i32 (i8*, ...)* @printf(i8* getelementptr inbounds ([3 x i8]* @"%i", i32 0, i32 0), i32 %9)
+  %10 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @"%i", i32 0, i32 0), i32 %9)
   br label %for.inc1
 
 for.inc1:                                         ; preds = %for.loop1

--- a/tests/input/if.ll
+++ b/tests/input/if.ll
@@ -4,7 +4,7 @@ define i32 @foo(i1 %x) {
 entry:
   %x.addr = alloca i1
   store i1 %x, i1* %x.addr
-  %0 = load i1* %x.addr
+  %0 = load i1, i1* %x.addr
   br i1 %0, label %if.then, label %if.else
 
 if.then:                                          ; preds = %entry

--- a/tests/input/loopnest.ll
+++ b/tests/input/loopnest.ll
@@ -6,21 +6,21 @@ define i32 @main() {
 entry:
   %0 = alloca i32
   store i32 0, i32* %0
-  %1 = load i32* %0
+  %1 = load i32, i32* %0
   %2 = alloca i32
   store i32 0, i32* %2
-  %3 = load i32* %2
+  %3 = load i32, i32* %2
   %4 = alloca i32
   store i32 0, i32* %4
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
-  %5 = load i32* %4
+  %5 = load i32, i32* %4
   %6 = icmp ult i32 %5, 10
   br i1 %6, label %for.loop, label %for.exit
 
 for.loop:                                         ; preds = %for.cond
-  %7 = load i32* %4
+  %7 = load i32, i32* %4
   %8 = alloca i32
   store i32 0, i32* %8
   br label %for.cond1
@@ -34,12 +34,12 @@ for.exit:                                         ; preds = %for.cond
   ret i32 0
 
 for.cond1:                                        ; preds = %for.inc1, %for.loop
-  %10 = load i32* %8
+  %10 = load i32, i32* %8
   %11 = icmp ult i32 %10, 20
   br i1 %11, label %for.loop1, label %for.exit1
 
 for.loop1:                                        ; preds = %for.cond1
-  %12 = load i32* %8
+  %12 = load i32, i32* %8
   %13 = call i32 @foo(i32 %1, i32 %3)
   br label %for.inc1
 

--- a/tests/input/multiple.ll
+++ b/tests/input/multiple.ll
@@ -4,7 +4,7 @@ define i32 @foo(i32 %x) {
 entry:
   %x.addr = alloca i32
   store i32 %x, i32* %x.addr
-  %0 = load i32* %x.addr
+  %0 = load i32, i32* %x.addr
   ret i32 %0
 }
 

--- a/tests/input/pair.ll
+++ b/tests/input/pair.ll
@@ -15,9 +15,9 @@ entry:
   store i32 100, i32* %1
   store float 2.000000e+02, float* %2
   %3 = getelementptr inbounds { i32, float }* %0, i32 0, i32 0
-  %4 = load i32* %3
+  %4 = load i32, i32* %3
   %5 = getelementptr inbounds { i32, float }* %0, i32 0, i32 1
-  %6 = load float* %5
+  %6 = load float, float* %5
   %7 = call i32 (i8*, ...)* @printf1(i8* getelementptr inbounds ([3 x i8]* @"%i", i32 0, i32 0), i32 %4)
   %8 = call i32 (i8*, ...)* @printf1(i8* getelementptr inbounds ([3 x i8]* @"%f", i32 0, i32 0), float %6)
   ret i32 %8

--- a/tests/input/pair.ll
+++ b/tests/input/pair.ll
@@ -10,15 +10,15 @@ declare i32 @printf1(i8*, ...)
 define i32 @main() {
 entry:
   %0 = alloca { i32, float }
-  %1 = getelementptr inbounds { i32, float }* %0, i32 0, i32 0
-  %2 = getelementptr inbounds { i32, float }* %0, i32 0, i32 1
+  %1 = getelementptr inbounds { i32, float }, { i32, float }* %0, i32 0, i32 0
+  %2 = getelementptr inbounds { i32, float }, { i32, float }* %0, i32 0, i32 1
   store i32 100, i32* %1
   store float 2.000000e+02, float* %2
-  %3 = getelementptr inbounds { i32, float }* %0, i32 0, i32 0
+  %3 = getelementptr inbounds { i32, float }, { i32, float }* %0, i32 0, i32 0
   %4 = load i32, i32* %3
-  %5 = getelementptr inbounds { i32, float }* %0, i32 0, i32 1
+  %5 = getelementptr inbounds { i32, float }, { i32, float }* %0, i32 0, i32 1
   %6 = load float, float* %5
-  %7 = call i32 (i8*, ...)* @printf1(i8* getelementptr inbounds ([3 x i8]* @"%i", i32 0, i32 0), i32 %4)
-  %8 = call i32 (i8*, ...)* @printf1(i8* getelementptr inbounds ([3 x i8]* @"%f", i32 0, i32 0), float %6)
+  %7 = call i32 (i8*, ...) @printf1(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @"%i", i32 0, i32 0), i32 %4)
+  %8 = call i32 (i8*, ...) @printf1(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @"%f", i32 0, i32 0), float %6)
   ret i32 %8
 }

--- a/tests/input/printf.ll
+++ b/tests/input/printf.ll
@@ -6,6 +6,6 @@ declare i32 @printf(i8*, ...)
 
 define i32 @main() {
 entry:
-  %0 = call i32 (i8*, ...)* @printf(i8* getelementptr inbounds ([3 x i8]* @"%i", i32 0, i32 0), i32 42)
+  %0 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @"%i", i32 0, i32 0), i32 42)
   ret i32 %0
 }

--- a/tests/input/range.ll
+++ b/tests/input/range.ll
@@ -9,12 +9,12 @@ entry:
   br label %for.cond
 
 for.cond:                                         ; preds = %for.inc, %entry
-  %1 = load i32* %0
+  %1 = load i32, i32* %0
   %2 = icmp ult i32 %1, 100
   br i1 %2, label %for.loop, label %for.exit
 
 for.loop:                                         ; preds = %for.cond
-  %3 = load i32* %0
+  %3 = load i32, i32* %0
   %4 = call i32 @foo(i32 %3)
   br label %for.inc
 

--- a/tests/input/record.ll
+++ b/tests/input/record.ll
@@ -4,6 +4,6 @@ define i32 @main() {
 entry:
   %0 = alloca { i32, float }
   %1 = getelementptr inbounds { i32, float }* %0, i32 0, i32 0
-  %2 = load i32* %1
+  %2 = load i32, i32* %1
   ret i32 %2
 }

--- a/tests/input/record.ll
+++ b/tests/input/record.ll
@@ -3,7 +3,7 @@
 define i32 @main() {
 entry:
   %0 = alloca { i32, float }
-  %1 = getelementptr inbounds { i32, float }* %0, i32 0, i32 0
+  %1 = getelementptr inbounds { i32, float }, { i32, float }* %0, i32 0, i32 0
   %2 = load i32, i32* %1
   ret i32 %2
 }


### PR DESCRIPTION
On the changes:
- vjoki@5946ff1: Fixes an issue with printing unnamed function parameters. For example the `hello.ll` test resulted in `define external ccc i32 @main(i32 %0, i8** %1){...}` which doesn't parse due to the unnamed parameters.
- vjoki@594d05c: Making `ftype` a pointer seems incorrect, the tests with printf calls failed due to this. Also I'm not seeing any reason to include `ftype` when the `resultType` is a pointer?
  * Example of incorrect output in isVarArg case:
    * input: `call i32 (i8*, ...) @printf`
    * output: `call ccc i32 (i8*, ...)* @printf`
  * And isFunctionPtr case:
    * input: `call i32 (i32)* @f`
    * output: `call ccc i32 (i32)* (i32, i32)* @f`
- vjoki@31e08a3: Would it be a good idea to remove the llp executable so packages depending on llvm-hs-pretty won't have to depend on llvm-hs?

Seems all the tests except `cast.ll` and `packed.ll` pass now.