### PR TITLE
Handle multiple UnNamed blocks

### DIFF
--- a/src/LLVM/Pretty.hs
+++ b/src/LLVM/Pretty.hs
@@ -327,7 +327,11 @@ instance PP GroupID where
 
 instance PP BasicBlock where
   pp (BasicBlock nm instrs term) =
-    pp nm <> ":" <$> indent 2 (vcat $ (fmap pp instrs) ++ [pp term])
+    label <$> indent 2 (vcat $ (fmap pp instrs) ++ [pp term])
+    where
+      label = case nm of
+        UnName _ -> "; <label>:" <> pp nm <> ":"
+        _ -> pp nm <> ":"
 
 instance PP Terminator where
   pp (Br dest meta) = "br" <+> label (pp dest)


### PR DESCRIPTION
If a function has multiple `UnName`d blocks it will print their labels as if they were `Name`d.
This produces invalid LLVM assembly.
The following code illustrates that.

``` haskell
{-# LANGUAGE OverloadedStrings #-}

import Control.Exception (handle)

import qualified Data.ByteString.Char8
import qualified Data.ByteString.Lazy
import qualified Data.Text.Lazy.Encoding
import qualified Data.Text.Lazy.IO

import LLVM.Pretty (ppllvm)

import LLVM.AST
import LLVM.AST.Global
import LLVM.AST.Type

import qualified LLVM.Context as LLVM
import qualified LLVM.Exception as LLVM
import qualified LLVM.Module as LLVM

defBool :: Definition
defBool = GlobalDefinition functionDefaults
  { name = Name "bool"
  , parameters =
      ( [ Parameter i1  (Name "c") []
        , Parameter i32 (Name "t") []
        , Parameter i32 (Name "e") [] ]
      , False )
  , returnType = i32
  , basicBlocks = 
      let
        c = LocalReference i1  (Name "c")
        t = LocalReference i32 (Name "t")
        e = LocalReference i32 (Name "e")
        r = LocalReference i32 (Name "r")
        then_ = UnName 1
        else_ = UnName 2
        join_ = UnName 3
      in
      [ BasicBlock (UnName 0) []
          ( Do $ CondBr c then_ else_ [] )
      , BasicBlock then_ []
          ( Do $ Br join_ [] )
      , BasicBlock else_ []
          ( Do $ Br join_ [] )
      , BasicBlock join_
          [ Name "r" := Phi i32 [ (t, then_), (e, else_) ] [] ]
          ( Do $ Ret (Just r) [] )
      ]
  }

astModule :: Module
astModule = defaultModule
  { moduleName = "llvm-pp"
  , moduleDefinitions = [defBool]
  }

main :: IO ()
main = do
  putStrLn "------------------------------------------------------------"
  putStrLn "-- ppllvm"
  putStrLn ""
  Data.Text.Lazy.IO.putStrLn (ppllvm astModule)
  putStrLn ""
  LLVM.withContext $ \context -> do
    putStrLn "------------------------------------------------------------"
    putStrLn "-- llvm-hs parser"
    putStrLn ""
    let assembly =
          Data.ByteString.Lazy.toStrict
          $ Data.Text.Lazy.Encoding.encodeUtf8
          $ ppllvm astModule
    handle (\(LLVM.ParseFailureException err) -> putStrLn err) $ do
      LLVM.withModuleFromLLVMAssembly context assembly $ const (pure ())
      putStrLn "OK"
    putStrLn "------------------------------------------------------------"
    putStrLn "-- llvm-hs pretty-printer"
    putStrLn ""
    LLVM.withModuleFromAST context astModule $ \llvm ->
      LLVM.moduleLLVMAssembly llvm >>= Data.ByteString.Char8.putStrLn
```

Without this PR the output is:

```
------------------------------------------------------------
-- ppllvm

; ModuleID = 'llvm-pp'

define external ccc i32 @bool(i1 %c, i32 %t, i32 %e){
0:
  br i1 %c, label %1, label %2
1:
  br label %3
2:
  br label %3
3:
  %r = phi i32 [%t, %1], [%e, %2]
  ret i32 %r
}

------------------------------------------------------------
-- llvm-hs parser

<string>:5:19: error: use of undefined value '%1'
  br i1 %c, label %1, label %2
                  ^


------------------------------------------------------------
-- llvm-hs pretty-printer

; ModuleID = 'llvm-pp'
source_filename = "<string>"

define i32 @bool(i1 %c, i32 %t, i32 %e) {
  br i1 %c, label %1, label %2

; <label>:1:                                      ; preds = %0
  br label %3

; <label>:2:                                      ; preds = %0
  br label %3

; <label>:3:                                      ; preds = %2, %1
  %r = phi i32 [ %t, %1 ], [ %e, %2 ]
  ret i32 %r
}
```

I.e. the LLVM parser throws an exception when attempting to parse the output of `llvm-hs-pretty`.
If we compare to the output of the LLVM pretty-printer,
we see that the `UnName`d labels are just comments.

With this PR the output is:

```
------------------------------------------------------------
-- ppllvm

; ModuleID = 'llvm-pp'

define external ccc i32 @bool(i1 %c, i32 %t, i32 %e){
; <label>:0:
  br i1 %c, label %1, label %2
; <label>:1:
  br label %3
; <label>:2:
  br label %3
; <label>:3:
  %r = phi i32 [%t, %1], [%e, %2]
  ret i32 %r
}

------------------------------------------------------------
-- llvm-hs parser

OK

...

```

The `UnName`d labels are printed as comments, and the LLVM parser no longer throws an exception.
