### PR TITLE
Fix test suite when run from sdist tarball

### DIFF
--- a/llvm-hs-pretty.cabal
+++ b/llvm-hs-pretty.cabal
@@ -10,7 +10,7 @@ build-type:          Simple
 category:            Compilers
 cabal-version:       >=1.10
 homepage:            https://github.com/llvm-hs/llvm-hs-pretty
-extra-source-files:  README.md ChangeLog.md
+extra-source-files:  README.md ChangeLog.md tests/input/*.ll
 
 Source-Repository head
     Type: git

--- a/src/LLVM/Pretty.hs
+++ b/src/LLVM/Pretty.hs
@@ -51,7 +51,7 @@ import qualified Data.ByteString.Short as SBF
 import qualified Data.ByteString.Lazy.Char8 as BF
 import Data.ByteString.Lazy (fromStrict)
 import Data.ByteString.Internal (w2c)
-import Text.PrettyPrint.Leijen.Text hiding (column, line)
+import Text.PrettyPrint.Leijen.Text hiding (column, line, (<>))
 
 import qualified Data.ByteString.Char8 as BL
 import qualified Data.ByteString.Short as BS
@@ -60,6 +60,7 @@ import Data.Foldable (toList)
 import Data.Int
 import Data.List (intersperse)
 import Data.Maybe (isJust, mapMaybe)
+import Data.Monoid ((<>))
 import Numeric (showHex)
 
 import Data.Array.Unsafe

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -46,6 +46,7 @@ testPath = "tests/input/"
 suite :: IO TestTree
 suite = do
   dirFiles <- listDirectory testPath
+  createDirectoryIfMissing True "tests/output"
   let testFiles = fmap (\x -> testPath </> x) dirFiles
   pure $ testGroup "Test Suite" [
     testGroup "Roundtrip Tests" $ fmap makeTest testFiles


### PR DESCRIPTION
This addresses #48 and also includes a compatibility fix for the new version of `wl-pprint-text`.