### PR TITLE
Added calling InlineAssembly

### DIFF
--- a/tests/input/asm.ll
+++ b/tests/input/asm.ll
@@ -1,0 +1,14 @@
+; ModuleID = '<string>'
+
+
+define external ccc i64 @main(){
+entry:
+  %X = alloca i64
+  store i64 1, i64* %X
+  %Y = load i64, i64* %X
+  %A = call i64 (i64) asm "addq $0, $0", "=r,r"(i64 %Y)
+  %B = call i64 (i64) asm alignstack inteldialect "sub $0, $0", "=r,r"(i64 %Y)
+  %C = call i64 asm alignstack "movq $$1, $0", "=r"()
+  %D = call i64 (i64) asm sideeffect "add $$1, $0", "=r,r"(i64  %Y)
+  ret i64 %D
+}


### PR DESCRIPTION
For https://github.com/llvm-hs/llvm-hs-pretty/issues/50.

Some output examples of what it produces:
```
  %A = call ccc i64 (i64) asm "addq $0, $0", "=r,r"(i64 %Y)
  %B = call ccc i64 (i64) asm alignstack inteldialect "sub $0, $0", "=r,r"(i64 %Y)
  %C = call ccc i64 () asm alignstack "movq $$1, $0", "=r"()
  %D = call ccc i64 (i64) asm sideeffect "add $$1, $0", "=r,r"(i64 %Y)
```