### PR TITLE
print clauses of landingpad before metadata

### DIFF
--- a/src/LLVM/Pretty.hs
+++ b/src/LLVM/Pretty.hs
@@ -544,8 +544,7 @@ instance PP Instruction where
     VAArg {..} -> "va_arg" <+> ppTyped argList `cma` pp type' <+> ppInstrMeta metadata
 
     LandingPad {..} ->
-      "landingpad" <+> pp type' <+> ppBool "cleanup" cleanup <+> ppInstrMeta metadata
-      <+> commas (fmap pp clauses)
+      "landingpad" <+> pp type' <+> ppBool "cleanup" cleanup <+> commas (fmap pp clauses) <+> ppInstrMeta metadata
     CatchPad {..} -> "catchpad" <+> "within" <+> pp catchSwitch <+> brackets (commas (map ppTyped args)) <+> ppInstrMeta metadata
     CleanupPad {..} -> "cleanuppad" <+> "within" <+> pp parentPad <+> brackets (commas (map ppTyped args)) <+> ppInstrMeta metadata
 


### PR DESCRIPTION
Hey guys - looking at the language reference for this instruction, I believe this change is a bug-fix https://llvm.org/docs/LangRef.html#landingpad-instruction