### PR TITLE
More descriptive error message instead of non exhaustive pattern message

### DIFF
--- a/src/LLVM/Pretty.hs
+++ b/src/LLVM/Pretty.hs
@@ -1281,7 +1281,9 @@ ppCall Call { function = Right f,..}
   = tail <+> "call" <+> pretty callingConvention <+> ppReturnAttributes returnAttributes <+> pretty resultType <+> ftype
     <+> pretty f <> parens (commas $ fmap ppArguments arguments) <+> ppFunctionAttributes functionAttributes
     where
-      (functionType@FunctionType {..}) = referencedType (typeOf f)
+      (functionType@FunctionType {..}) = case (referencedType (typeOf f)) of
+                                           fty@FunctionType {..} -> fty
+                                           _ -> error "Calling non function type"
       ftype = if isVarArg
               then ppFunctionArgumentTypes functionType
               else mempty


### PR DESCRIPTION
When mistakenly calling a function without the `FunctionType` type, the error message thrown is `non-exhaustive patterns`. It might be useful to the API consumer to get a better error message.