### PR TITLE
Instruction returning void cannot have a name

### DIFF
--- a/src/LLVM/Pretty.hs
+++ b/src/LLVM/Pretty.hs
@@ -532,7 +532,10 @@ instance Pretty Instruction where
 
     ICmp {..}   -> "icmp" <+> pretty iPredicate <+> ppTyped operand0 `cma` pretty operand1 <+> ppInstrMeta metadata
 
-    c@Call {..} -> ppCall c  <+> ppInstrMeta metadata
+    c@Call { function = f, ..} ->
+      case f of
+        (Right (LocalReference VoidType _)) -> error "instructions returning void cannot have a name"
+        _ -> ppCall c  <+> ppInstrMeta metadata
     Select {..} -> "select" <+> commas [ppTyped condition', ppTyped trueValue, ppTyped falseValue] <+> ppInstrMeta metadata
     SExt {..}   -> "sext" <+> ppTyped operand0 <+> "to" <+> pretty type' <+> ppInstrMeta metadata <+> ppInstrMeta metadata
     ZExt {..}   -> "zext" <+> ppTyped operand0 <+> "to" <+> pretty type' <+> ppInstrMeta metadata <+> ppInstrMeta metadata

--- a/src/LLVM/Pretty.hs
+++ b/src/LLVM/Pretty.hs
@@ -534,7 +534,6 @@ instance Pretty Instruction where
 
     c@Call { function = f, ..} ->
       case f of
-        (Right (LocalReference VoidType _)) -> error "instructions returning void cannot have a name"
         (Right (ConstantOperand (C.GlobalReference (FunctionType VoidType _ _) _))) ->
           error "instructions returning void cannot have a name"
         _ -> ppCall c  <+> ppInstrMeta metadata

--- a/src/LLVM/Pretty.hs
+++ b/src/LLVM/Pretty.hs
@@ -535,6 +535,8 @@ instance Pretty Instruction where
     c@Call { function = f, ..} ->
       case f of
         (Right (LocalReference VoidType _)) -> error "instructions returning void cannot have a name"
+        (Right (ConstantOperand (C.GlobalReference (FunctionType VoidType _ _) _))) ->
+          error "instructions returning void cannot have a name"
         _ -> ppCall c  <+> ppInstrMeta metadata
     Select {..} -> "select" <+> commas [ppTyped condition', ppTyped trueValue, ppTyped falseValue] <+> ppInstrMeta metadata
     SExt {..}   -> "sext" <+> ppTyped operand0 <+> "to" <+> pretty type' <+> ppInstrMeta metadata <+> ppInstrMeta metadata


### PR DESCRIPTION
In the current llvm compiler Instructions returning void (like call to a global reference which returns void) cannot be assigned to a variable. The library currently allows us to do that. For instance something like:

```
...
%2 = call fastcc  void  @foo(%struct.bar*  %1, i64  4)
...
```

is allowed which is rejected by `llc`. This patch adds an error message instead of emitting the faulty IR.

However it simply throws an error message without pointing to the line number of the offending instruction. `llc` has a better UI in that it points to the specific line number that causes the error. I am unsure if we should let the user construct the faulty IR and let `llc` point the error or simply throw an error at this library.