### PR TITLE
Updates for LLVM 12

### DIFF
--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -1,7 +1,7 @@
 resolver: lts-16.31
 
 packages:
-- url: https://github.com/llvm-hs/llvm-hs/archive/8bdab2a59db31618f097a7bb05f7b374e6a96fc4.tar.gz
+- url: https://github.com/llvm-hs/llvm-hs/archive/4aad4c4060a582c49116b70037d96eb863891e20.tar.gz
   subdirs:
   - llvm-hs
   - llvm-hs-pure

--- a/src/LLVM/Pretty.hs
+++ b/src/LLVM/Pretty.hs
@@ -505,6 +505,7 @@ instance Pretty Terminator where
 
 instance Pretty Instruction where
   pretty = \case
+    FNeg {..}   -> "fneg" <+> (pretty fastMathFlags) <+> ppTyped operand0 <+> ppInstrMeta metadata
     Add {..}    -> ppInstrWithNuwNsw "add" nuw nsw operand0 operand1 metadata
     Sub {..}    -> ppInstrWithNuwNsw "sub" nuw nsw operand0 operand1 metadata
     Mul {..}    -> ppInstrWithNuwNsw "mul" nuw nsw operand0 operand1 metadata
@@ -794,7 +795,7 @@ instance Pretty DICompileUnit where
     , ("splitDebugInlining", Just (ppBoolean splitDebugInlining))
     , ("debugInfoForProfiling", Just (ppBoolean debugInfoForProfiling))
     , ("nameTableKind", Just (pretty nameTableKind))
-    , ("debugBaseAddress", Just (ppBoolean debugBaseAddress))
+    , ("rangesBaseAddress", Just (ppBoolean rangesBaseAddress))
     ]
 
 instance Pretty DebugEmissionKind where

--- a/tests/input/func.ll
+++ b/tests/input/func.ll
@@ -84,7 +84,7 @@ declare void @f63(i32 %x, i32, ...)
 declare void @f64(i32 %x, i32 %y, ...)
 
 ; Parameter attributes.
-declare void @f65(i32 "foo" "bar"="baz" align 8 byval dereferenceable(11) dereferenceable_or_null(22) inalloca inreg nest noalias nocapture nonnull readnone readonly returned signext sret swifterror swiftself writeonly zeroext %x)
+declare void @f65(i32 "foo" "bar"="baz" align 8 byval(i32) dereferenceable(11) dereferenceable_or_null(22) inalloca inreg nest noalias nocapture nonnull readnone readonly returned signext sret(i32) swifterror swiftself writeonly zeroext %x)
 
 ; Unnamed address.
 declare void @f66() local_unnamed_addr
@@ -116,7 +116,7 @@ declare void @f75() prologue i32 42
 declare void @f76() personality i32 42
 
 ; Full function declaration.
-declare !foo !{!"bar"} !baz !{!"qux"} external default dllimport ccc "foo" "bar"="baz" align 8 dereferenceable(11) dereferenceable_or_null(22) inreg noalias i32 @f77(i32 %x, i32 "foo" "bar"="baz" align 8 byval dereferenceable(11) dereferenceable_or_null(22) inalloca inreg nest noalias nocapture nonnull readnone readonly returned signext sret swifterror swiftself writeonly zeroext %y, ...) unnamed_addr "foo" "bar"="baz" #0 #1 alignstack(8) allocsize(16) allocsize(32, 64) alwaysinline argmemonly cold convergent inaccessiblemem_or_argmemonly inaccessiblememonly inlinehint jumptable minsize naked nobuiltin noduplicate noimplicitfloat noinline nonlazybind norecurse noredzone noreturn nounwind optnone optsize readnone readonly returns_twice safestack sanitize_address sanitize_memory sanitize_thread ssp sspreq sspstrong uwtable writeonly section "foo" comdat($com1) align 8 gc "foo" prefix i32 42 prologue i32 42 personality i32 42
+declare !foo !{!"bar"} !baz !{!"qux"} external default dllimport ccc "foo" "bar"="baz" align 8 dereferenceable(11) dereferenceable_or_null(22) inreg noalias i32 @f77(i32 %x, i32 "foo" "bar"="baz" align 8 byval(i32) dereferenceable(11) dereferenceable_or_null(22) inalloca inreg nest noalias nocapture nonnull readnone readonly returned signext sret(i32) swifterror swiftself writeonly zeroext %y, ...) unnamed_addr "foo" "bar"="baz" #0 #1 alignstack(8) allocsize(16) allocsize(32, 64) alwaysinline argmemonly cold convergent inaccessiblemem_or_argmemonly inaccessiblememonly inlinehint jumptable minsize naked nobuiltin noduplicate noimplicitfloat noinline nonlazybind norecurse noredzone noreturn nounwind optnone optsize readnone readonly returns_twice safestack sanitize_address sanitize_memory sanitize_thread ssp sspreq sspstrong uwtable writeonly section "foo" comdat($com1) align 8 gc "foo" prefix i32 42 prologue i32 42 personality i32 42
 
 ; Plain function definition.
 define void @f78() {
@@ -158,7 +158,7 @@ define void @f88() !foo !{!"bar"} !baz !{!"qux"} {
 }
 
 ; Full function definition.
-define available_externally default dllimport ccc "foo" "bar"="baz" align 8 dereferenceable(11) dereferenceable_or_null(22) inreg noalias i32 @f89(i32 %x, i32 "foo" "bar"="baz" align 8 byval dereferenceable(11) dereferenceable_or_null(22) inalloca inreg nest noalias nocapture nonnull readnone readonly returned signext sret swifterror swiftself writeonly zeroext %y, ...) unnamed_addr "foo" "bar"="baz" #0 #1 alignstack(8) allocsize(16) allocsize(32, 64) alwaysinline argmemonly cold convergent inaccessiblemem_or_argmemonly inaccessiblememonly inlinehint jumptable minsize naked nobuiltin noduplicate noimplicitfloat noinline nonlazybind norecurse noredzone noreturn nounwind optnone optsize readnone readonly returns_twice safestack sanitize_address sanitize_memory sanitize_thread ssp sspreq sspstrong uwtable writeonly section "foo" comdat($com1) align 8 gc "foo" prefix i32 42 prologue i32 42 personality i32 42 !foo !{!"bar"} !baz !{!"qux"} {
+define available_externally default dllimport ccc "foo" "bar"="baz" align 8 dereferenceable(11) dereferenceable_or_null(22) inreg noalias i32 @f89(i32 %x, i32 "foo" "bar"="baz" align 8 byval(i32) dereferenceable(11) dereferenceable_or_null(22) inalloca inreg nest noalias nocapture nonnull readnone readonly returned signext sret(i32) swifterror swiftself writeonly zeroext %y, ...) unnamed_addr "foo" "bar"="baz" #0 #1 alignstack(8) allocsize(16) allocsize(32, 64) alwaysinline argmemonly cold convergent inaccessiblemem_or_argmemonly inaccessiblememonly inlinehint jumptable minsize naked nobuiltin noduplicate noimplicitfloat noinline nonlazybind norecurse noredzone noreturn nounwind optnone optsize readnone readonly returns_twice safestack sanitize_address sanitize_memory sanitize_thread ssp sspreq sspstrong uwtable writeonly section "foo" comdat($com1) align 8 gc "foo" prefix i32 42 prologue i32 42 personality i32 42 !foo !{!"bar"} !baz !{!"qux"} {
 	ret i32 42
 }
 


### PR DESCRIPTION
Handle the FNeg instruction, and fix a lot of failing tests by applying the LLVM rename of "debugBaseAddr" to "rangesBaseAddr" in DICompileUnit. Also byval and sret attributes take mandatory arguments now (adjusted tests to pass these arguments)