### PR TITLE
LLVM 12 work

### DIFF
--- a/llvm-hs-pretty.cabal
+++ b/llvm-hs-pretty.cabal
@@ -29,7 +29,7 @@ library
     bytestring           >= 0.1   && < 0.11,
     llvm-hs-pure         >= 12    && < 13,
     text                 >= 1.2   && < 2.0,
-    prettyprinter        >= 1.6   && < 1.7
+    prettyprinter        >= 1.6
 
 Test-suite test
   type:                exitcode-stdio-1.0

--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -1,7 +1,7 @@
-resolver: lts-16.31
+resolver: lts-17.12
 
 packages:
-- url: https://github.com/llvm-hs/llvm-hs/archive/4aad4c4060a582c49116b70037d96eb863891e20.tar.gz
+- url: https://github.com/llvm-hs/llvm-hs/archive/refs/heads/llvm-12.zip
   subdirs:
   - llvm-hs
   - llvm-hs-pure

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,4 +13,4 @@ flags:
     shared-llvm: true
 
 ghc-options:
-  llvm-hs: -optcxx=-std=c++11
+  llvm-hs: -optcxx=-std=c++14

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,4 +13,4 @@ flags:
     shared-llvm: true
 
 ghc-options:
-  llvm-hs: -optcxx=-std=c++14
+  llvm-hs: -optcxx=-std=c++14 -optcxx=-lstdc++ -optcxx=-fno-rtti

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,17 +1,16 @@
-resolver: lts-16.31
-
-# Use snapshot.yaml when testing locally against an unreleased llvm-hs version
-#resolver: snapshot.yaml
+#resolver: lts-17.12
+resolver: snapshot.yaml
 
 packages:
 - '.'
 
-# Comment extra-deps out when running tests against snapshot.yaml
-extra-deps:
-- llvm-hs-12.0.0
-- llvm-hs-pure-12.0.0
+#extra-deps:
+#- llvm-hs-12.0.0
+#- llvm-hs-pure-12.0.0
 
 flags:
   llvm-hs:
     shared-llvm: true
 
+ghc-options:
+  llvm-hs: -optcxx=-std=c++11


### PR DESCRIPTION
Fix a stale version constraint, apply a fix for cabal mishandling options to the backend compiler. Move to the latest Stackage LTS release (17.12)