### PR TITLE
Fix handling of GlobalAlias

### DIFF
--- a/src/LLVM/Pretty.hs
+++ b/src/LLVM/Pretty.hs
@@ -271,9 +271,7 @@ instance Pretty Global where
       kind | isConstant = "constant"
            | otherwise  = "global"
 
-  pretty GlobalAlias {..} = global (pretty name) <+> "=" <+> pretty linkage <+> ppMaybe unnamedAddr <+> "alias" <+> pretty typ `cma` ppTyped aliasee
-    where
-      typ = getElementType type'
+  pretty GlobalAlias {..} = global (pretty name) <+> "=" <+> pretty linkage <+> ppMaybe unnamedAddr <+> "alias" <+> pretty type' `cma` ppTyped aliasee
 
 ppFunctionAttribute :: Either GroupID FunctionAttribute -> Doc ann
 ppFunctionAttribute (Left grpId) = pretty grpId

--- a/tests/input/alias.ll
+++ b/tests/input/alias.ll
@@ -1,0 +1,7 @@
+; ModuleID = 'simple module'
+
+define i32 @foo() {
+  ret i32 42
+}
+
+@bar = external alias i32 (), i32 ()* @foo


### PR DESCRIPTION
The rule for GlobalAlias was assuming the type of the alias matches the type of the aliasee (and both were pointers), but actually the aliasee is to be a pointer-to-type-of-the-alias.

Adding a test-case that otherwise fails