### PR TITLE
Fix as-pattern for GHC 9.

### DIFF
--- a/src/LLVM/Pretty.hs
+++ b/src/LLVM/Pretty.hs
@@ -475,7 +475,7 @@ instance Pretty Terminator where
      brackets (hsep [ label (pretty l) | l <- dests ])
      <+> ppInstrMeta meta
 
-    e @ Invoke {..} ->
+    e@Invoke {..} ->
      ppInvoke e
      <+> "to" <+> label (pretty returnDest)
      <+> "unwind" <+> label (pretty exceptionDest)


### PR DESCRIPTION
Fixes the following error:
```
src/LLVM/Pretty.hs:478:7: error:
    Found a binding for the ‘@’ operator in a pattern position.
    Perhaps you meant an as-pattern, which must not be surrounded by whitespace
    |
478 |     e @ Invoke {..} ->
```