### PR TITLE
Relax version constraint for prettyprinter

### DIFF
--- a/llvm-hs-pretty.cabal
+++ b/llvm-hs-pretty.cabal
@@ -30,7 +30,7 @@ library
     bytestring           >= 0.1   && < 0.11,
     llvm-hs-pure         >= 9.0   && < 10.0,
     text                 >= 1.2   && < 2.0,
-    prettyprinter        >= 1.2   && < 1.6
+    prettyprinter        >= 1.2   && < 1.8
 
 Test-suite test
   type:                exitcode-stdio-1.0


### PR DESCRIPTION
My compiler uses prettyprinter 1.7.*, while this package's version boundary was lagging behind.

I ran `stack test` before and after updating it in the cabal file, seems to work exactly the same. (Also my tests that use ppllvm in my compiler.)