### PR TITLE
Handle named references in structs correctly 

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,21 +1,21 @@
-{ mkDerivation, base, bytestring, directory, filepath, llvm-hs
-, llvm-hs-pure, mtl, pretty-show, stdenv, tasty, tasty-golden
-, tasty-hspec, tasty-hunit, text, transformers, wl-pprint-text
+{ mkDerivation, array, base, bytestring, directory, filepath, lib
+, llvm-hs llvm-hs-pure, mtl, prettyprinter, tasty, tasty-golden
+, tasty-hspec, tasty-hunit, text, transformers
 }:
 mkDerivation {
   pname = "llvm-hs-pretty";
   version = "0.1.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    base bytestring llvm-hs-pure text wl-pprint-text
+    array base bytestring llvm-hs-pure text prettyprinter
   ];
   testHaskellDepends = [
-    base directory filepath llvm-hs llvm-hs-pure mtl pretty-show tasty
+    base directory filepath llvm-hs llvm-hs-pure mtl tasty
     tasty-golden tasty-hspec tasty-hunit text transformers
   ];
   doHaddock = false;
-  doCheck = false;
+  doCheck = true;
   homepage = "https://github.com/llvm-hs/llvm-hs-pretty";
   description = "Pretty printer for LLVM IR";
-  license = stdenv.lib.licenses.mit;
+  license = lib.licenses.mit;
 }

--- a/src/LLVM/Pretty/Typed.hs
+++ b/src/LLVM/Pretty/Typed.hs
@@ -38,7 +38,9 @@ instance Typed C.Constant where
   typeOf (C.Float t) = typeOf t
   typeOf (C.Null t)      = t
   typeOf (C.AggregateZero t) = t
-  typeOf (C.Struct {..}) = StructureType isPacked (map typeOf memberValues)
+  typeOf (C.Struct {..}) = case structName of
+                             Just name -> NamedTypeReference name
+                             Nothing   -> StructureType isPacked (map typeOf memberValues)
   typeOf (C.Array {..})  = ArrayType (fromIntegral $ length memberValues) memberType
   typeOf (C.Vector {..}) = VectorType (fromIntegral $ length memberValues) $
                               case memberValues of

--- a/tests/input/named-struct.ll
+++ b/tests/input/named-struct.ll
@@ -1,0 +1,6 @@
+; ModuleID = 'simple module'
+
+%struct.coord2d = type {i32, i32}
+%struct.vector = type {%struct.coord2d, %struct.coord2d}
+
+@up = global %struct.vector {%struct.coord2d {i32 0, i32 0}, %struct.coord2d {i32 0, i32 1}}


### PR DESCRIPTION
The added test-case would previously fail since:

```llvm
; ModuleID = 'simple module'

%struct.coord2d = type {i32, i32}
%struct.vector = type {%struct.coord2d, %struct.coord2d}

@up = global %struct.vector {%struct.coord2d {i32 0, i32 0}, %struct.coord2d {i32 0, i32 1}}
```

would get pretty-printed as invalid code:

```llvm
; ModuleID = 'simple module'

%struct.coord2d = type {i32, i32}
%struct.vector = type {%struct.coord2d, %struct.coord2d}

@up = global %struct.vector {%struct.coord2d zeroinitializer, {i32 0, i32 0} {i32 0, i32 1}}
```

To run the tests, I had to update the nix support, that had bitrot